### PR TITLE
Use KV Store library to make the call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/statsig-io/fastly-data-adapter-go
 
 go 1.23.5
+
+require github.com/fastly/compute-sdk-go v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/fastly/compute-sdk-go v1.3.3 h1:Wf4P9J49ay9gpmzGXB1SLXy2i69TwPa4maPJ9n3UTy4=
+github.com/fastly/compute-sdk-go v1.3.3/go.mod h1:AdOwbVc56tusuDLtufaO57NIzfoox4bgvRc460B/T8o=


### PR DESCRIPTION
Currently the Fastly Data Adapter is making an API call to **fastly config store** in order to retrieve the contents of the config stored under the configSpecKey

`	req, err := http.NewRequest("GET", fmt.Sprintf("https://api.fastly.com/resources/stores/config/%s/item/%s", f.storeID, f.configSpecsKey), nil)
`

1. We should, instead, be making a call to the KV Store
2. We shouldn't have to make an API call to fastly. We should instead be able to use the KV Store import that Go provides. After already having specified the Fastly API Key and the KV Store ID (https://docs.statsig.com/integrations/fastly/#overview) we should already have access to Fastly resources and shouldn't have to explicitly make an API call.